### PR TITLE
flipper_gui: add rpc_send_virtual_display_frame()

### DIFF
--- a/flipperzero_protobuf/flipper_gui.py
+++ b/flipperzero_protobuf/flipper_gui.py
@@ -61,6 +61,23 @@ class FlipperProtoGui:
                 self.Status_values_by_number[rep_data.command_status].name
             )
 
+    # SendVirtualDisplayFrame
+    def rpc_send_virtual_display_frame(self, data) -> None:
+        """Send Frame to Virtual Display
+
+        Parameters
+        ----------
+        data : bytes
+
+        Returns
+        -------
+        None
+
+        """
+        cmd_data = gui_pb2.ScreenFrame()
+        cmd_data.data = data
+        self._rpc_send(cmd_data, "gui_screen_frame")
+
     # StopVirtualDisplay
     def rpc_stop_virtual_display(self) -> None:
         """Stop Virtual Display


### PR DESCRIPTION
Added rpc_send_virtual_display_frame() to the flipper_gui
It allows to send images to the Flipper's screen via virtual_display.

Backward compatibility:
- No need to recompile flipperzero-protobuf